### PR TITLE
MACD must not overwrite the global variables

### DIFF
--- a/src/indicator/macd.js
+++ b/src/indicator/macd.js
@@ -19,10 +19,7 @@ module.exports = function(indicatorMixin, accessor_ohlc, indicator_ema) {  // In
       slowAverage.accessor(indicator.accessor()).period(slow).init();
 
       return data.map(function(d, i) {
-        slow = fastAverage.average(p.accessor(d));
-        fast = slowAverage.average(p.accessor(d));
-
-        var macd = slow - fast,
+        var macd = fastAverage.average(p.accessor(d)) - slowAverage.average(p.accessor(d)),
             signalValue = i >= minFastSlow ? signalLine.average(macd) : null;
 
         if(i >= minCount) return datum(p.accessor.d(d), macd, signalValue, macd - signalValue, 0);


### PR DESCRIPTION
The fast and slow variables must be set in MACD initialization, otherwise
live update of the MACD doesn't work correctly.

This makes it work, though it's still not perfect, it gets distorted for a small moment when updating the indicator, but at least it works.  I tick my chart forward, for example every minute, even if there is no new data, so the distortion appears to happen at that point.

Also, the MACD is *really* slow.  It's because the histogram is generated with bars.  It might be better to change it to a line and area, should be much much more lightweight.