### PR TITLE
verify d3 available on window object

### DIFF
--- a/src/techan.js
+++ b/src/techan.js
@@ -2,8 +2,8 @@
 
 var _d3;
 
-// If running in browser (window !undefined), assume d3 available
-if('undefined' != typeof window) _d3 = window.d3;
+// If running in browser (window !undefined) and d3 available
+if('undefined' != typeof window && window.d3) _d3 = window.d3;
 else if('object' == typeof module) _d3 = require('d3'); // else we're in the only other supported mode: v8/node
 else throw "Unsupported runtime environment: Could not find d3. Ensure defined globally on window, or available as dependency.";
 


### PR DESCRIPTION
This patch makes it so that the code works as the error message says it should. It also lets techan work with `webpack` (because `window` is defined but d3 still has to be `require`d as per the elseif clause)
