### PR TITLE
RFC: make horizontal lines render in alignment with monitor pixels

### DIFF
--- a/src/plot/axisannotation.js
+++ b/src/plot/axisannotation.js
@@ -73,7 +73,7 @@ module.exports = function(d3_svg_axis, d3_scale_linear, accessor_value, plot, pl
 function refresh(selection, accessor, axis, orient, format, height, width, point, translate) {
   var neg = orient === 'left' || orient === 'top' ? -1 : 1;
 
-  selection.attr('transform', 'translate(' + translate[0] + ',' + translate[1] + ')');
+  selection.attr('transform', 'translate(' + translate[0] + ',' + (translate[1] - 0.5) + ')');
   selection.select('path').attr('d', backgroundPath(accessor, axis, orient, height, width, point, neg));
   selection.select('text').text(textValue(accessor, format)).call(textAttributes, accessor, axis, orient, neg);
 }

--- a/src/plot/crosshair.js
+++ b/src/plot/crosshair.js
@@ -127,6 +127,8 @@ module.exports = function(d3_select, d3_event, d3_mouse, d3_dispatch, accessor_c
         if(p.accessor.yv(d) === null) return null;
         var value = p.yScale(p.accessor.yv(d));
         if(isNaN(value)) return null;
+        else value -= 0.5;
+
         return 'M ' + range[0] + ' ' + value + ' L ' + range[range.length-1] + ' ' + value;
       };
     }

--- a/src/plot/plot.js
+++ b/src/plot/plot.js
@@ -243,10 +243,11 @@ module.exports = function(d3_svg_line, d3_svg_area, d3_line_interpolate, d3_sele
         if(!d.length) return null;
 
         var firstDatum = d[0],
-            lastDatum = d[d.length-1];
+            lastDatum = d[d.length-1],
+            yValue = Math.floor(y(accessor_value(firstDatum))) + 0.5;
 
-        return 'M ' + x(accessor_date(firstDatum)) + ' ' + y(accessor_value(firstDatum)) +
-          ' L ' + x(accessor_date(lastDatum)) + ' ' + y(accessor_value(lastDatum));
+        return 'M ' + x(accessor_date(firstDatum)) + ' ' + yValue +
+          ' L ' + x(accessor_date(lastDatum)) + ' ' + yValue;
       };
     },
 


### PR DESCRIPTION
Hi. I noticed that horizontal lines were often rendering in a "blurry" way, and this PR is the result of my trip down the rabbit hole of SVG rendering. ([See this answer on StackOverflow, and the comment on it.](http://stackoverflow.com/questions/7401369/why-is-svg-stroke-width-1-making-lines-transparent#answer-7436476))

The short of it is, horizontal/vertical lines should be drawn on _half_ pixel values, instead of integer pixel values. You can see upstream d3 does this when drawing axes ([link to relevant source code](https://github.com/d3/d3-axis/blob/master/src/axis.js#L46)).

If you look at my changes, you'll notice that for drawing the crosshairs I used `-0.5`, while for indicator plots I used `+0.5`. I don't have a logical explanation for you there, other than that visually, those modifications seem to reliably give the desired result. (Yea, kinda hand wavy... I wish I had a better understanding of why, but, no such luck :( To see what I mean, compare the overbought/oversold lines to the axis ticks d3 draws, and the crosshair line to the crosshair cursor the OS draws. It helps if you turn off dasharray/opacity styles.)

Other comments:
- Vertical lines seem to already be correct. Perhaps a side effect of using d3.scale for positioning? Did not investigate.
- I didn't clean up the tests, because, well, these few changes break a very disproportionate number of them and I wanted to hear your thoughts before spending any more time on this particular issue.

Thanks!
