### PR TITLE
RFC: refactor overbought/oversold lines

### DIFF
--- a/src/plot/plot.js
+++ b/src/plot/plot.js
@@ -238,15 +238,20 @@ module.exports = function(d3_svg_line, d3_svg_area, d3_line_interpolate, d3_sele
 
     appendPathsUpDownEqual: appendPathsUpDownEqual,
 
-    horizontalPathLine: function(accessor_date, x, accessor_value, y) {
+    horizontalPathLine: function(accessor_date, x, yValue, y) {
       return function(d) {
         if(!d.length) return null;
+
+        // "accessor_value" compatibility
+        if(typeof yValue === 'function') {
+            yValue = y(yValue(firstDatum));
+        }
 
         var firstDatum = d[0],
             lastDatum = d[d.length-1];
 
-        return 'M ' + x(accessor_date(firstDatum)) + ' ' + y(accessor_value(firstDatum)) +
-          ' L ' + x(accessor_date(lastDatum)) + ' ' + y(accessor_value(lastDatum));
+        return 'M ' + x(accessor_date(firstDatum)) + ' ' + yValue +
+          ' L ' + x(accessor_date(lastDatum)) + ' ' + yValue;
       };
     },
 

--- a/src/plot/rsi.js
+++ b/src/plot/rsi.js
@@ -1,9 +1,13 @@
 'use strict';
 
 module.exports = function(accessor_rsi, plot, plotMixin) {  // Injected dependencies
-  return function() { // Closure function
+  return function(options) { // Closure function
+    if (!options) options = {};
     var p = {},  // Container for private, direct access mixed in variables
-        rsiLine = plot.pathLine();
+        rsiLine = plot.pathLine(),
+        overbought = options.overbought ? options.overbought : 70,
+        middle = options.middle ? options.middle : 50,
+        oversold = options.overbought ? options.overbought : 30;
 
     function rsi(g) {
       var group = p.dataSelector(g);
@@ -17,7 +21,7 @@ module.exports = function(accessor_rsi, plot, plotMixin) {  // Injected dependen
     }
 
     rsi.refresh = function(g) {
-      refresh(p.dataSelector.select(g), p.accessor, p.xScale, p.yScale, plot, rsiLine);
+      refresh(p.dataSelector.select(g), p.accessor, p.xScale, p.yScale, plot, rsiLine, overbought, middle, oversold);
     };
 
     function binder() {
@@ -32,9 +36,9 @@ module.exports = function(accessor_rsi, plot, plotMixin) {  // Injected dependen
   };
 };
 
-function refresh(selection, accessor, x, y, plot, rsiLine) {
-  selection.select('path.overbought').attr('d', plot.horizontalPathLine(accessor.d, x, accessor.ob, y));
-  selection.select('path.middle').attr('d', plot.horizontalPathLine(accessor.d, x, accessor.m, y));
-  selection.select('path.oversold').attr('d', plot.horizontalPathLine(accessor.d, x, accessor.os, y));
+function refresh(selection, accessor, x, y, plot, rsiLine, overbought, middle, oversold) {
+  selection.select('path.overbought').attr('d', plot.horizontalPathLine(accessor.d, x, overbought, y));
+  selection.select('path.middle').attr('d', plot.horizontalPathLine(accessor.d, x, middle, y));
+  selection.select('path.oversold').attr('d', plot.horizontalPathLine(accessor.d, x, oversold, y));
   selection.select('path.rsi').attr('d', rsiLine);
 }


### PR DESCRIPTION
When drawing horizontal lines, by definition, there's only one y value. Currently however, for overbought/oversold lines, the y value needs to be passed in for every x value. Indicator calculations do not need knowledge of these values, only the plotters. Furthermore, there are "standard" defaults for all the indicators, so my idea is to instantiate the plotters with overrides if desired, like so:

``` javascript
// these are the defaults, just showing proposed syntax
var rsi = techan.plot.rsi({overbought: 70, oversold: 30})
    .xScale(xScale)
    .yScale(rsiYScale)
// everything else stays the same
```

There wouldn't be any BC breaks with such a change. Working code for RSI attached. What do you think?
